### PR TITLE
Shorten tiltes in pages, wrap it better.

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 
 # -- PROJECT Variables ----------------------------------------------------
-settings_project_name = 'Piano triennale per l\'informatica nella PA 2017 - 2019'
+settings_project_name = 'Piano triennale per l\'informatica nella PA<br />2017 - 2019'
 settings_copyright_year = '2017'
 settings_copyright_name = 'AgID - Agenzia per l\'Italia Digitale'
 settings_doc_version = '1'
@@ -100,7 +100,7 @@ else:
 
 # The name for this set of Sphinx documents.  If None, it defaults to
 # "<project> v<release> documentation".
-#html_title = None
+html_title = "Piano Triennale 2017 - 2019"
 
 # A shorter title for the navigation bar.  Default is the same as html_title.
 #html_short_title = None

--- a/index.rst
+++ b/index.rst
@@ -1,4 +1,4 @@
-PIANO TRIENNALE PER L’INFORMATICA NELLA PUBBLICA AMMINISTRAZIONE 2017 - 2019
+PIANO TRIENNALE PER L'INFORMATICA NELLA PUBBLICA AMMINISTRAZIONE 2017 - 2019
 ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 .. toctree::


### PR DESCRIPTION
Two changes:

1) The title in the left sidebar, goes on the new line after 2017 -,
   leaving 2019 on the new line. Add an explicit br, so 2017 - 2019
   should always be on a line on its own.

2) The title of most web pages has "Piano Triennale per l'informatica
   nella PA - 2017 - 2019 1.0 documentazione" appended to it.
   When the chapter is named "Piano Triennale per l'informatica
   ...", and the title is appended, you have "Piano Triennale
   blah blah Piano Triennale blah blah" twice.

   It's too long, bad for SEO and just an eyesore. Make it shorter.
   It's now set to "Piano Triennale 2017 - 2019"

