### PR TITLE
Fix the spacing of footnotes.

### DIFF
--- a/_themes/sphinx_italia_theme/static/css/theme.css
+++ b/_themes/sphinx_italia_theme/static/css/theme.css
@@ -4470,10 +4470,13 @@ input[type="radio"][disabled], input[type="checkbox"][disabled] {
 
 /* RESPONSIVE TABLES */
 .wy-table-responsive {
-  margin-bottom: 24px;
   max-width: 100%;
   overflow: auto;
 }
+.wy-table-responsive:last-child {
+  margin-bottom: 24px;
+}
+
 .wy-table-responsive table {
   margin-bottom: 0 !important;
 }


### PR DESCRIPTION
Two notes:

1) a simple grep -r of the class shows it is only set by javascript
   on footnotes, so nothing else should be affected.

2) before and after screenshots:

     https://ibb.co/dUAJHa
     https://ibb.co/c3WQxa

