### PR TITLE
Leave more of the page space for actual content.

### DIFF
--- a/_themes/sphinx_italia_theme/static/css/theme.css
+++ b/_themes/sphinx_italia_theme/static/css/theme.css
@@ -5512,7 +5512,6 @@ div[class^='highlight'] pre {
 }
 
 .wy-nav-content {
-  padding: 1.618em 3.236em;
   height: 100%;
   max-width: 800px;
   margin: auto;


### PR DESCRIPTION
The current layout leaves many pixels between the left navigation
bar and the content of the body. This is a static value.

In this change, removed the static spacing, left the padding of
the parent object, which seems to be more than enough.

Look at the difference in the two screenshots:

https://ibb.co/jDz3Ha
https://ibb.co/bUFzqv

Note: I tested this locally and with the default phone simulator
in chromium. Scrolled through the pages, and they look ok, including
tables.

