### PR TITLE
Revert 0592a9803e34c9f69e168eb88cfaacf8e0423c77.

### DIFF
--- a/_themes/sphinx_italia_theme/static/css/theme.css
+++ b/_themes/sphinx_italia_theme/static/css/theme.css
@@ -5515,6 +5515,7 @@ div[class^='highlight'] pre {
 }
 
 .wy-nav-content {
+  padding: 1.618em 3.236em;
   height: 100%;
   max-width: 800px;
   margin: auto;


### PR DESCRIPTION
Unfortunately, that change breaks under IE: leaves
no space whatsover between the sidebar and the body.

Works in chromium and firefox.

